### PR TITLE
Fix for [RfwNode.parse] not parsing children correctly 

### DIFF
--- a/lib/ui/editor/model.dart
+++ b/lib/ui/editor/model.dart
@@ -136,11 +136,25 @@ const _defaultJson = '''
 const _defaultRfw = '''
 import widgets;
 
-widget root = Center(
-  child: Button(
-    child: Text(text: ["Hello ", data.greet.name]),
-    onPressed: event "click" {},
-  ),
+widget root = Column(
+  children: [
+    Button(
+      child: Text(text: ["Hello ", data.greet.name]),
+      onPressed: event "click" {},
+    ),
+    Button(
+      child: Text(text: ["Hello ", data.greet.name]),
+      onPressed: event "click" {},
+    ),
+    Button(
+      child: Text(text: ["Hello ", data.greet.name]),
+      onPressed: event "click" {},
+    ),
+    Button(
+      child: Text(text: ["Hello ", data.greet.name]),
+      onPressed: event "click" {},
+    ),
+  ] 
 );
 
 widget Button { down: false } = GestureDetector(
@@ -277,6 +291,26 @@ class RfwNode {
       // AnyEventHandler val => EventNode(val, parent),
       // DataReference val => DataNode(val, parent),
       // Object? val => ValueNode(val, parent),
+
+      final List<Object?> children => () {
+          final node = RfwNode(
+            target,
+            '',
+            parent: parent,
+            prefix: prefix,
+            color: Colors.green,
+          );
+          for (final child in children) {
+            node.children.add(
+              RfwNode.parse(
+                child,
+                parent: node,
+                prefix: child?.toString(),
+              ),
+            );
+          }
+          return node;
+        }(),
       (Object? _) => RfwNode(
           target ?? Object(),
           'Value',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,18 +116,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -156,18 +156,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -257,10 +257,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   type_plus:
     dependency: transitive
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
 sdks:
   dart: ">=3.4.3 <4.0.0"
   flutter: ">=3.22.0"


### PR DESCRIPTION
fixes #5 

before:
![Screenshot 2024-09-01 at 9 21 13 AM](https://github.com/user-attachments/assets/5031840d-e288-49e0-be49-7339663fa6a8)


after: 
![Screenshot 2024-09-01 at 9 20 31 AM](https://github.com/user-attachments/assets/f6878a69-1a74-4645-b1a3-5e39772aefe5)

there are 2 changes currently,
first the `defaultRfw` is modified to show a Column of buttons instead of one button.

and,
while parsing the string to `RfwNode`, before checking the default `(Object?)` I am checking for `List<Object?>`.